### PR TITLE
Allow connections from host and guest as well as public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+qemuc

--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,6 @@ Networking
 ----------
 
 This section describes the theory behind the generated iptables statements.
-To see a real-world example, the test_setup function (in test_qemu.py)
-shows a simple JSON configuration and the iptables rules that it produces.
 
 Packets arriving on the public interface are DNATed to the virtual machine.
 This implements the actual port-forwarding.  Due to the way iptables is
@@ -45,17 +43,22 @@ implemented, the DNAT must occur in two chains: nat:PREROUTING for packets
 arriving on the public interface, and nat:OUTPUT for packets originating on
 the host.
 
-We also add rules to the FORWARD chain to ensure the repsonses to the
-DNATed packets return to the public IP address.
+We also add rules to the FORWARD chain to ensure the repsonses return.
 
 Finally, packets originating on the guest and sent to the host's public IP
-address are lost.  They are DNATed back to the guest like any other packet but,
-because the destination is now the same as the source, the reply is swallowed.
-Therefore, the host SNATs these packets to ensure the guest sends its reply
-back over the bridge.
+address need special handling.  They are DNATed back to the guest like all
+other packets but, because the destination is now the same as the source,
+the reply never leaves the guest.  Therefore, the host SNATs these packets
+to ensure the reply returns over the bridge.
+
+To see a real-world example, the ``test_setup`` function in test_qemu.py_
+demonstrates a simple JSON configuration and the iptables rules that it produces.
+
+.. _test_qemu.py: test_qemu.py
 
 
-Author
-------
+Authors
+-------
 
-Sascha Peilicke
+- Sascha Peilicke
+- Scott Bronson

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,29 @@ Testing
     python -m unittest discover
 
 
+Networking
+----------
+
+This section describes the theory behind the generated iptables statements.
+To see a real-world example, the test_setup function (in test_qemu.py)
+shows a simple JSON configuration and the iptables rules that it produces.
+
+Packets arriving on the public interface are DNATed to the virtual machine.
+This implements the actual port-forwarding.  Due to the way iptables is
+implemented, the DNAT must occur in two chains: nat:PREROUTING for packets
+arriving on the public interface, and nat:OUTPUT for packets originating on
+the host.
+
+We also add rules to the FORWARD chain to ensure the repsonses to the
+DNATed packets return to the public IP address.
+
+Finally, packets originating on the guest and sent to the host's public IP
+address are lost.  They are DNATed back to the guest like any other packet but,
+because the destination is now the same as the source, the reply is swallowed.
+Therefore, the host SNATs these packets to ensure the guest sends its reply
+back over the bridge.
+
+
 Author
 ------
 

--- a/qemu
+++ b/qemu
@@ -121,8 +121,9 @@ def delete_chain(table, name):
     subprocess.call([IPTABLES_BINARY, "-t", table, "-F", name])
     subprocess.call([IPTABLES_BINARY, "-t", table, "-X", name])
 
-def populate_chains(port_map, dnat_chain, snat_chain, fwd_chain, public_ip, private_ip):
+def populate_chains(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip, domain):
     """ Fills the two custom chains with the port mappings. """
+    port_map = domain["port_map"]
     for protocol in port_map:
         for ports in port_map[protocol]:
             # a single integer 80 is equivalent to [80, 80]
@@ -132,8 +133,9 @@ def populate_chains(port_map, dnat_chain, snat_chain, fwd_chain, public_ip, priv
                 "-d", public_ip, "--dport", str(public_port), "-j", "DNAT", "--to", dest])
             subprocess.call([IPTABLES_BINARY, "-t", "nat", "-A", snat_chain, "-p", protocol,
                 "-s", private_ip, "-d", private_ip, "--dport", str(public_port), "-j", "MASQUERADE"])
+            interface = ["-o", domain["interface"]] if "interface" in domain else []
             subprocess.call([IPTABLES_BINARY, "-t", "filter", "-A", fwd_chain, "-p", protocol,
-                "-d", private_ip, "--dport", str(private_port), "-j", "ACCEPT"])
+                "-d", private_ip, "--dport", str(private_port), "-j", "ACCEPT"] + interface)
 
 def insert_chains(action, dnat_chain, snat_chain, fwd_chain, public_ip, private_ip):
     """ inserts (action='-I') or removes (action='-D') the custom chains."""
@@ -148,13 +150,13 @@ def disable_bridge_filtering():
         brnf.write('0\n')
 
 
-def start_forwarding(port_map, dnat_chain, snat_chain, fwd_chain, public_ip, private_ip):
+def start_forwarding(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip, domain):
     """ sets up iptables port-forwarding rules based on the port_map. """
     disable_bridge_filtering()
     create_chain("nat", dnat_chain)
     create_chain("nat", snat_chain)
     create_chain("filter", fwd_chain)
-    populate_chains(port_map, dnat_chain, snat_chain, fwd_chain, public_ip, private_ip)
+    populate_chains(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip, domain)
     insert_chains("-I", dnat_chain, snat_chain, fwd_chain, public_ip, private_ip)
 
 
@@ -181,4 +183,4 @@ if __name__ == "__main__":
     if action in ["stopped", "reconnect"]:
         stop_forwarding(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip)
     if action in ["start", "reconnect"]:
-        start_forwarding(domain["port_map"], dnat_chain, snat_chain, fwd_chain, public_ip, private_ip)
+        start_forwarding(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip, domain)

--- a/qemu
+++ b/qemu
@@ -133,11 +133,8 @@ def populate_chains(port_map, dnat_chain, fwd_chain, public_ip, private_ip):
             subprocess.call([IPTABLES_BINARY, "-t", "filter", "-A", fwd_chain, "-p", protocol,
                 "-d", private_ip, "--dport", str(private_port), "-j", "ACCEPT"])
 
-def establish_chains(action, dnat_chain, fwd_chain, public_ip, private_ip):
-    """ inserts or removes the custom chains.
-
-    if action is "-I" then the custom chains are inserted, otherwise "-D" deletes them
-    """
+def insert_chains(action, dnat_chain, fwd_chain, public_ip, private_ip):
+    """ inserts (action='-I') or removes (action='-D') the custom chains."""
     subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "OUTPUT", "-d", public_ip, "-j", dnat_chain])
     subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "PREROUTING", "-d", public_ip, "-j", dnat_chain])
     subprocess.call([IPTABLES_BINARY, "-t", "filter", action, "FORWARD", "-d", private_ip, "-j", fwd_chain])
@@ -149,12 +146,12 @@ def start_forwarding(port_map, dnat_chain, fwd_chain, public_ip, private_ip):
     create_chain("nat", dnat_chain)
     create_chain("filter", fwd_chain)
     populate_chains(port_map, dnat_chain, fwd_chain, public_ip, private_ip)
-    establish_chains("-I", dnat_chain, fwd_chain, public_ip, private_ip)
+    insert_chains("-I", dnat_chain, fwd_chain, public_ip, private_ip)
 
 
 def stop_forwarding(dnat_chain, fwd_chain, public_ip, private_ip):
     """ tears down the iptables port-forwarding rules. """
-    establish_chains("-D", dnat_chain, fwd_chain, public_ip, private_ip)
+    insert_chains("-D", dnat_chain, fwd_chain, public_ip, private_ip)
     delete_chain("nat", dnat_chain)
     delete_chain("filter", fwd_chain)
 

--- a/qemu
+++ b/qemu
@@ -111,36 +111,52 @@ def config(validate=True):
     return config._conf
 
 
-def iptables_forward(action, domain):
-    """Set iptables port-forwarding rules based on domain configuration.
 
-    Args:
-        action: iptables rule actions (one of '-I', '-A' or '-D')
-        domain: Libvirt domain configuration
+def create_chain(table, name):
+    """ Creates the named chain. """
+    subprocess.call([IPTABLES_BINARY, "-t", table, "-N", name])
+
+def delete_chain(table, name):
+    """ Flushes and deletes the named chain. """
+    subprocess.call([IPTABLES_BINARY, "-t", table, "-F", name])
+    subprocess.call([IPTABLES_BINARY, "-t", table, "-X", name])
+
+def populate_chains(port_map, dnat_chain, fwd_chain, public_ip, private_ip):
+    """ Fills the two custom chains with the port mappings. """
+    for protocol in port_map:
+        for ports in port_map[protocol]:
+            # a single integer 80 is equivalent to [80, 80]
+            public_port, private_port = ports if isinstance(ports, list) else [ports, ports]
+            dest = "{0}:{1}".format("private_ip", str(private_port))
+            subprocess.call([IPTABLES_BINARY, "-t", "nat", "-A", dnat_chain, "-p", protocol,
+                "-d", public_ip, "--dport", str(public_port), "-j", "DNAT", "--to", dest])
+            subprocess.call([IPTABLES_BINARY, "-t", "filter", "-A", fwd_chain, "-p", protocol,
+                "-d", private_ip, "--dport", str(private_port), "-j", "ACCEPT"])
+
+def establish_chains(action, dnat_chain, fwd_chain, public_ip, private_ip):
+    """ inserts or removes the custom chains.
+
+    if action is "-I" then the custom chains are inserted, otherwise "-D" deletes them
     """
-    public_ip = domain.get("public_ip", host_ip())
-    # Iterate over protocols (tcp, udp, icmp, ...)
-    for protocol in domain["port_map"]:
-        # Iterate over all public/private port pairs for the protocol
-        for port_map in domain["port_map"].get(protocol):
-            # allow a single integer 80 to be equivalent to [80, 80]
-            public_port, private_port = port_map if isinstance(port_map, list) else [port_map, port_map]
+    subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "OUTPUT", "-d", public_ip, "-j", dnat_chain])
+    subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "PREROUTING", "-d", public_ip, "-j", dnat_chain])
+    subprocess.call([IPTABLES_BINARY, "-t", "filter", action, "FORWARD", "-d", private_ip, "-j", fwd_chain])
 
-            args = [IPTABLES_BINARY,
-                    "-t", "nat", action, "PREROUTING",
-                    "-p", protocol,
-                    "-d", public_ip, "--dport", str(public_port),
-                    "-j", "DNAT", "--to", "{0}:{1}".format(domain["private_ip"], str(private_port))]
-            subprocess.call(args)
 
-            args = [IPTABLES_BINARY,
-                    "-t", "filter", action, "FORWARD",
-                    "-p", protocol,
-                    "-d", domain["private_ip"], "--dport", str(private_port),
-                    "-j", "ACCEPT"]
-            if "interface" in domain:
-                args += ["-o", domain["interface"]]
-            subprocess.call(args)
+
+def start_forwarding(port_map, dnat_chain, fwd_chain, public_ip, private_ip):
+    """ sets up iptables port-forwarding rules based on the port_map. """
+    create_chain("nat", dnat_chain)
+    create_chain("filter", fwd_chain)
+    populate_chains(port_map, dnat_chain, fwd_chain, public_ip, private_ip)
+    establish_chains("-I", dnat_chain, fwd_chain, public_ip, private_ip)
+
+
+def stop_forwarding(dnat_chain, fwd_chain, public_ip, private_ip):
+    """ tears down the iptables port-forwarding rules. """
+    establish_chains("-D", dnat_chain, fwd_chain, public_ip, private_ip)
+    delete_chain("nat", dnat_chain)
+    delete_chain("filter", fwd_chain)
 
 
 if __name__ == "__main__":
@@ -148,7 +164,13 @@ if __name__ == "__main__":
     domain = config().get(vir_domain)
     if domain is None:
         sys.exit(0)
+
+    dnat_chain = "DNAT-{0}".format(vir_domain)
+    fwd_chain = "FWD-{0}".format(vir_domain)
+    public_ip = domain.get("public_ip", host_ip())
+    private_ip = domain["private_ip"]
+
     if action in ["stopped", "reconnect"]:
-        iptables_forward("-D", domain)
+        stop_forwarding(dnat_chain, fwd_chain, public_ip, private_ip)
     if action in ["start", "reconnect"]:
-        iptables_forward("-I", domain)
+        start_forwarding(domain["port_map"], dnat_chain, fwd_chain, public_ip, private_ip)

--- a/qemu
+++ b/qemu
@@ -121,7 +121,7 @@ def delete_chain(table, name):
     subprocess.call([IPTABLES_BINARY, "-t", table, "-F", name])
     subprocess.call([IPTABLES_BINARY, "-t", table, "-X", name])
 
-def populate_chains(port_map, dnat_chain, fwd_chain, public_ip, private_ip):
+def populate_chains(port_map, dnat_chain, snat_chain, fwd_chain, public_ip, private_ip):
     """ Fills the two custom chains with the port mappings. """
     for protocol in port_map:
         for ports in port_map[protocol]:
@@ -130,29 +130,39 @@ def populate_chains(port_map, dnat_chain, fwd_chain, public_ip, private_ip):
             dest = "{0}:{1}".format(private_ip, str(private_port))
             subprocess.call([IPTABLES_BINARY, "-t", "nat", "-A", dnat_chain, "-p", protocol,
                 "-d", public_ip, "--dport", str(public_port), "-j", "DNAT", "--to", dest])
+            subprocess.call([IPTABLES_BINARY, "-t", "nat", "-A", snat_chain, "-p", protocol,
+                "-s", private_ip, "-d", private_ip, "--dport", str(public_port), "-j", "MASQUERADE"])
             subprocess.call([IPTABLES_BINARY, "-t", "filter", "-A", fwd_chain, "-p", protocol,
                 "-d", private_ip, "--dport", str(private_port), "-j", "ACCEPT"])
 
-def insert_chains(action, dnat_chain, fwd_chain, public_ip, private_ip):
+def insert_chains(action, dnat_chain, snat_chain, fwd_chain, public_ip, private_ip):
     """ inserts (action='-I') or removes (action='-D') the custom chains."""
     subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "OUTPUT", "-d", public_ip, "-j", dnat_chain])
     subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "PREROUTING", "-d", public_ip, "-j", dnat_chain])
+    subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "POSTROUTING", "-s", private_ip, "-d", private_ip, "-j", snat_chain])
     subprocess.call([IPTABLES_BINARY, "-t", "filter", action, "FORWARD", "-d", private_ip, "-j", fwd_chain])
 
+# the snat_chain doesn't work unless we turn off filtering bridged packets
+def disable_bridge_filtering():
+    with open('/proc/sys/net/bridge/bridge-nf-call-iptables', 'w') as brnf:
+        brnf.write('0\n')
 
 
-def start_forwarding(port_map, dnat_chain, fwd_chain, public_ip, private_ip):
+def start_forwarding(port_map, dnat_chain, snat_chain, fwd_chain, public_ip, private_ip):
     """ sets up iptables port-forwarding rules based on the port_map. """
+    disable_bridge_filtering()
     create_chain("nat", dnat_chain)
+    create_chain("nat", snat_chain)
     create_chain("filter", fwd_chain)
-    populate_chains(port_map, dnat_chain, fwd_chain, public_ip, private_ip)
-    insert_chains("-I", dnat_chain, fwd_chain, public_ip, private_ip)
+    populate_chains(port_map, dnat_chain, snat_chain, fwd_chain, public_ip, private_ip)
+    insert_chains("-I", dnat_chain, snat_chain, fwd_chain, public_ip, private_ip)
 
 
-def stop_forwarding(dnat_chain, fwd_chain, public_ip, private_ip):
+def stop_forwarding(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip):
     """ tears down the iptables port-forwarding rules. """
-    insert_chains("-D", dnat_chain, fwd_chain, public_ip, private_ip)
+    insert_chains("-D", dnat_chain, snat_chain, fwd_chain, public_ip, private_ip)
     delete_chain("nat", dnat_chain)
+    delete_chain("nat", snat_chain)
     delete_chain("filter", fwd_chain)
 
 
@@ -163,11 +173,12 @@ if __name__ == "__main__":
         sys.exit(0)
 
     dnat_chain = "DNAT-{0}".format(vir_domain)
+    snat_chain = "SNAT-{0}".format(vir_domain)
     fwd_chain = "FWD-{0}".format(vir_domain)
     public_ip = domain.get("public_ip", host_ip())
     private_ip = domain["private_ip"]
 
     if action in ["stopped", "reconnect"]:
-        stop_forwarding(dnat_chain, fwd_chain, public_ip, private_ip)
+        stop_forwarding(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip)
     if action in ["start", "reconnect"]:
-        start_forwarding(domain["port_map"], dnat_chain, fwd_chain, public_ip, private_ip)
+        start_forwarding(domain["port_map"], dnat_chain, snat_chain, fwd_chain, public_ip, private_ip)

--- a/qemu
+++ b/qemu
@@ -127,7 +127,7 @@ def populate_chains(port_map, dnat_chain, fwd_chain, public_ip, private_ip):
         for ports in port_map[protocol]:
             # a single integer 80 is equivalent to [80, 80]
             public_port, private_port = ports if isinstance(ports, list) else [ports, ports]
-            dest = "{0}:{1}".format("private_ip", str(private_port))
+            dest = "{0}:{1}".format(private_ip, str(private_port))
             subprocess.call([IPTABLES_BINARY, "-t", "nat", "-A", dnat_chain, "-p", protocol,
                 "-d", public_ip, "--dport", str(public_port), "-j", "DNAT", "--to", dest])
             subprocess.call([IPTABLES_BINARY, "-t", "filter", "-A", fwd_chain, "-p", protocol,

--- a/qemu.json
+++ b/qemu.json
@@ -1,5 +1,6 @@
 {
     "cloud-admin": {
+        "interface": "virbr1",            // you can use comments
         "private_ip": "192.168.124.10",   /* both styles */
         "port_map": {
             "tcp": [[1100, 3000], 443]

--- a/qemu.json
+++ b/qemu.json
@@ -1,13 +1,11 @@
 {
     "cloud-admin": {
-        "interface": "virbr1",            // you can use comments
         "private_ip": "192.168.124.10",   /* both styles */
         "port_map": {
             "tcp": [[1100, 3000], 443]
         }
     },
     "cloud-node1": {
-        "interface": "virbr1",
         "private_ip": "192.168.126.2",
         "port_map": {
             "tcp": [[1101, 80],

--- a/test_qemu.py
+++ b/test_qemu.py
@@ -3,6 +3,7 @@ import json
 import os
 import socket
 import sys
+import textwrap
 import unittest
 
 qemu = imp.load_source('qemu', 'qemu')
@@ -24,21 +25,66 @@ class QemuTestCase(unittest.TestCase):
         conf = qemu.config()
         del qemu.config._conf  # Revert closure
 
+    def capture_output(self, func):
+        outfile = "/tmp/libvirt-hook-qemu-test-output.txt"
+        orig_binary = qemu.IPTABLES_BINARY
+        orig_out = os.dup(sys.stdout.fileno())
+
+        try:
+            qemu.IPTABLES_BINARY = '/bin/echo'
+            to = open(outfile, "w")
+            os.dup2(to.fileno(), sys.stdout.fileno())
+            func()
+        finally:
+            sys.stdout.flush()
+            os.dup2(orig_out, sys.stdout.fileno())
+            qemu.IPTABLES_BINARY = orig_binary
+
+        output = open(outfile).read()
+        os.remove(outfile)
+        return output
+
     def test_setup(self):
         port_map = {
+            "udp": [53],
             "tcp": [[80, 8080], 443]
         }
 
-        qemu.IPTABLES_BINARY = '/bin/echo'
-        outfile = "/tmp/ttp"
-        orig = os.dup(sys.stdout.fileno())
-        try:
-            to = open(outfile, "w")
-            os.dup2(to.fileno(), sys.stdout.fileno())
+        expected_output = textwrap.dedent("""
+            -t nat -N DNAT-test
+            -t filter -N FWD-test
+            -t nat -A DNAT-test -p udp -d 192.168.1.1 --dport 53 -j DNAT --to 127.0.0.1:53
+            -t filter -A FWD-test -p udp -d 127.0.0.1 --dport 53 -j ACCEPT
+            -t nat -A DNAT-test -p tcp -d 192.168.1.1 --dport 80 -j DNAT --to 127.0.0.1:8080
+            -t filter -A FWD-test -p tcp -d 127.0.0.1 --dport 8080 -j ACCEPT
+            -t nat -A DNAT-test -p tcp -d 192.168.1.1 --dport 443 -j DNAT --to 127.0.0.1:443
+            -t filter -A FWD-test -p tcp -d 127.0.0.1 --dport 443 -j ACCEPT
+            -t nat -I OUTPUT -d 192.168.1.1 -j DNAT-test
+            -t nat -I PREROUTING -d 192.168.1.1 -j DNAT-test
+            -t filter -I FORWARD -d 127.0.0.1 -j FWD-test
+        """[1:])
+
+        def test_func():
             qemu.start_forwarding(port_map, "DNAT-test", "FWD-test", "192.168.1.1", "127.0.0.1")
-        finally:
-            sys.stdout.flush()
-            os.dup2(orig, sys.stdout.fileno())
+
+        output = self.capture_output(test_func)
+        self.maxDiff = None
+        self.assertMultiLineEqual(output, expected_output)
 
     def test_teardown(self):
-        pass
+        expected_output = textwrap.dedent("""
+            -t nat -D OUTPUT -d 192.168.1.1 -j DNAT-test
+            -t nat -D PREROUTING -d 192.168.1.1 -j DNAT-test
+            -t filter -D FORWARD -d 127.0.0.1 -j FWD-test
+            -t nat -F DNAT-test
+            -t nat -X DNAT-test
+            -t filter -F FWD-test
+            -t filter -X FWD-test
+        """[1:])
+
+        def test_func():
+            qemu.stop_forwarding("DNAT-test", "FWD-test", "192.168.1.1", "127.0.0.1")
+
+        output = self.capture_output(test_func)
+        self.maxDiff = None
+        self.assertMultiLineEqual(output, expected_output)

--- a/test_qemu.py
+++ b/test_qemu.py
@@ -44,13 +44,16 @@ class QemuTestCase(unittest.TestCase):
         os.remove(outfile)
         return output
 
+    def dedent(self, str):
+        return textwrap.dedent(str[1:])
+
     def test_setup(self):
         port_map = {
             "udp": [53],
             "tcp": [[80, 8080], 443]
         }
 
-        expected_output = textwrap.dedent("""
+        expected_output = self.dedent("""
             -t nat -N DNAT-test
             -t filter -N FWD-test
             -t nat -A DNAT-test -p udp -d 192.168.1.1 --dport 53 -j DNAT --to 127.0.0.1:53
@@ -62,7 +65,7 @@ class QemuTestCase(unittest.TestCase):
             -t nat -I OUTPUT -d 192.168.1.1 -j DNAT-test
             -t nat -I PREROUTING -d 192.168.1.1 -j DNAT-test
             -t filter -I FORWARD -d 127.0.0.1 -j FWD-test
-        """[1:])
+        """)
 
         def test_func():
             qemu.start_forwarding(port_map, "DNAT-test", "FWD-test", "192.168.1.1", "127.0.0.1")
@@ -72,7 +75,7 @@ class QemuTestCase(unittest.TestCase):
         self.assertMultiLineEqual(output, expected_output)
 
     def test_teardown(self):
-        expected_output = textwrap.dedent("""
+        expected_output = self.dedent("""
             -t nat -D OUTPUT -d 192.168.1.1 -j DNAT-test
             -t nat -D PREROUTING -d 192.168.1.1 -j DNAT-test
             -t filter -D FORWARD -d 127.0.0.1 -j FWD-test
@@ -80,7 +83,7 @@ class QemuTestCase(unittest.TestCase):
             -t nat -X DNAT-test
             -t filter -F FWD-test
             -t filter -X FWD-test
-        """[1:])
+        """)
 
         def test_func():
             qemu.stop_forwarding("DNAT-test", "FWD-test", "192.168.1.1", "127.0.0.1")

--- a/test_qemu.py
+++ b/test_qemu.py
@@ -1,6 +1,8 @@
 import imp
 import json
+import os
 import socket
+import sys
 import unittest
 
 qemu = imp.load_source('qemu', 'qemu')
@@ -12,7 +14,7 @@ class QemuTestCase(unittest.TestCase):
         try:
             socket.inet_aton(host_ip)
         except socket.error:
-            pass  # Not legal 
+            pass  # Not legal
 
     def test_config(self):
         conf = qemu.config(validate=False)
@@ -21,3 +23,22 @@ class QemuTestCase(unittest.TestCase):
     def test_config_schema_validation(self):
         conf = qemu.config()
         del qemu.config._conf  # Revert closure
+
+    def test_setup(self):
+        port_map = {
+            "tcp": [[80, 8080], 443]
+        }
+
+        qemu.IPTABLES_BINARY = '/bin/echo'
+        outfile = "/tmp/ttp"
+        orig = os.dup(sys.stdout.fileno())
+        try:
+            to = open(outfile, "w")
+            os.dup2(to.fileno(), sys.stdout.fileno())
+            qemu.start_forwarding(port_map, "DNAT-test", "FWD-test", "192.168.1.1", "127.0.0.1")
+        finally:
+            sys.stdout.flush()
+            os.dup2(orig, sys.stdout.fileno())
+
+    def test_teardown(self):
+        pass

--- a/test_qemu.py
+++ b/test_qemu.py
@@ -60,13 +60,13 @@ class QemuTestCase(unittest.TestCase):
             -t filter -N FWD-test
             -t nat -A DNAT-test -p udp -d 192.168.1.1 --dport 53 -j DNAT --to 127.0.0.1:53
             -t nat -A SNAT-test -p udp -s 127.0.0.1 -d 127.0.0.1 --dport 53 -j MASQUERADE
-            -t filter -A FWD-test -p udp -d 127.0.0.1 --dport 53 -j ACCEPT
+            -t filter -A FWD-test -p udp -d 127.0.0.1 --dport 53 -j ACCEPT -o virbr0
             -t nat -A DNAT-test -p tcp -d 192.168.1.1 --dport 80 -j DNAT --to 127.0.0.1:8080
             -t nat -A SNAT-test -p tcp -s 127.0.0.1 -d 127.0.0.1 --dport 80 -j MASQUERADE
-            -t filter -A FWD-test -p tcp -d 127.0.0.1 --dport 8080 -j ACCEPT
+            -t filter -A FWD-test -p tcp -d 127.0.0.1 --dport 8080 -j ACCEPT -o virbr0
             -t nat -A DNAT-test -p tcp -d 192.168.1.1 --dport 443 -j DNAT --to 127.0.0.1:443
             -t nat -A SNAT-test -p tcp -s 127.0.0.1 -d 127.0.0.1 --dport 443 -j MASQUERADE
-            -t filter -A FWD-test -p tcp -d 127.0.0.1 --dport 443 -j ACCEPT
+            -t filter -A FWD-test -p tcp -d 127.0.0.1 --dport 443 -j ACCEPT -o virbr0
             -t nat -I OUTPUT -d 192.168.1.1 -j DNAT-test
             -t nat -I PREROUTING -d 192.168.1.1 -j DNAT-test
             -t nat -I POSTROUTING -s 127.0.0.1 -d 127.0.0.1 -j SNAT-test
@@ -81,7 +81,8 @@ class QemuTestCase(unittest.TestCase):
         qemu.disable_bridge_filtering = disable_bridge_filtering
 
         def test_func():
-            qemu.start_forwarding(port_map, "DNAT-test", "SNAT-test", "FWD-test", "192.168.1.1", "127.0.0.1")
+            domain = { "port_map": port_map, "interface": "virbr0" }
+            qemu.start_forwarding("DNAT-test", "SNAT-test", "FWD-test", "192.168.1.1", "127.0.0.1", domain)
 
         output = self.capture_output(test_func)
         self.maxDiff = None


### PR DESCRIPTION
This is an experiment that seems to have worked...  Submitting it to see what you think, happy to modify or ignore.

I had three problems with the qemu hook:

* Connecting from the host to the forwarded port fails.  Packets from the host to the public IP are lost because apparently DNAT needs to happen in the OUTPUT chain as well as PREROUTING (some iptables thing).
* Connecting from the guest to the forwarded port fails.  Packets from the guest to the public IP are lost because they need to be SNATed for the reply to be routed correctly.
* if you edit `qemu.json` while a guest is running, the guest's rules won't be removed when it stops.  You either need to reboot the host or clean them up by hand.

This patchset addresses all three concerns.  It adds some rules, and it creates new chains for the rules so they can be flushed and deleted without regard to what their contents are.

One potential issue is that I no longer support "interface" in the JSON config since I didn't see any use for it.  If anyone has a use case that requires it, I can add it back.

Just for reference, some iptables discussion that went into this patchset:
* http://marc.info/?t=144918284000003&r=1&w=2
* http://marc.info/?t=144922229800002&r=1&w=2