### PR TITLE
Fix host_ip when multiple default routes exist

### DIFF
--- a/hooks
+++ b/hooks
@@ -77,7 +77,7 @@ def host_ip():
     specify a different public IP to forward from.
     """
     if not hasattr(host_ip, "_host_ip"):
-        cmd = "ip route | grep default | cut -d' ' -f5"
+        cmd = "ip route | grep default | cut -d' ' -f5 | head -n1"
         default_route_interface = subprocess.check_output(cmd, shell=True).decode().strip()
         cmd = "ip addr show {0} | grep -E 'inet .*{0}' | cut -d' ' -f6 | cut -d'/' -f1".format(default_route_interface)
         host_ip._host_ip = subprocess.check_output(cmd, shell=True).decode().strip()


### PR DESCRIPTION
On systems with multiple default routes, the `host_ip` function misbehaved and passed garbage to iptables.

Add a ` | head -n1` at the end of the interface query command to only look at the first default route (which should have the highest metric in `ip route`'s output).