### PR TITLE
masquerade outgoing connections to public_ip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+python:
+  - "2.7"
+  #- "3.6"
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ install:
 	ln -s ${LIBVIRT_HOOKS_DIR}/hooks ${LIBVIRT_HOOKS_DIR}/qemu
 	ln -s ${LIBVIRT_HOOKS_DIR}/hooks ${LIBVIRT_HOOKS_DIR}/lxc
 
+test:
+	python -m unittest discover
+
 clean:
 	rm ${LIBVIRT_HOOKS_DIR}/hooks{,.json,.schema.json}
 	rm ${LIBVIRT_HOOKS_DIR}/qemu

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,12 @@ install:
 test:
 	python -m unittest discover
 
-clean:
+uninstall:
 	rm ${LIBVIRT_HOOKS_DIR}/hooks{,.json,.schema.json}
 	rm ${LIBVIRT_HOOKS_DIR}/qemu
 	rm ${LIBVIRT_HOOKS_DIR}/lxc
+
+clean:
+	@rm *.pyc ||:
+	@rm -r __pycache__/ ||:
+	@rm hooksc ||:

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Makefile_:
 
     $ sudo make install
 
-Afterwards customize :file:`/etc/libvirt/hooks/qemu.json` to your needs.
+Afterwards customize */etc/libvirt/hooks/qemu.json* to your needs.
 This Makefile target can be invoked multiple times, already installed
 configuration files won't be touched. The files can be removed again with:
 

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ implemented, the DNAT must occur in two chains: nat:PREROUTING for packets
 arriving on the public interface, and nat:OUTPUT for packets originating on
 the host.
 
-We also add rules to the FORWARD chain to ensure the repsonses return.
+We also add rules to the FORWARD chain to ensure the responses return.
 
 Finally, packets originating on the guest and sent to the host's public IP
 address need special handling.  They are DNATed back to the guest like all

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://travis-ci.org/saschpe/libvirt-hook-qemu.svg?branch=master
+    :target: https://travis-ci.org/saschpe/libvirt-hook-qemu
+
 Libvirt port-forwarding hook
 ============================
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Installation
 ------------
 
 To install the hook script and it's configuration files, simply use the
-:file:`Makefile`:
+Makefile_:
 
 .. code-block:: bash
 
@@ -30,7 +30,7 @@ configuration files won't be touched. The files can be removed again with:
 Testing
 -------
 
-To run unit tests use the *test* target of the :file:`Makefile`:
+To run unit tests use the ``test`` target of the Makefile_:
 
 .. code-block:: bash
 
@@ -65,11 +65,13 @@ to ensure the reply returns over the bridge.
 To see a real-world example, the ``test_setup`` function in test_qemu.py_
 demonstrates a simple JSON configuration and the iptables rules that it produces.
 
-.. _test_qemu.py: test_qemu.py
-
 
 Authors
 -------
 
 - Sascha Peilicke
 - Scott Bronson
+
+
+.. _Makefile: Makefile
+.. _test_qemu.py: test_qemu.py

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ configuration files won't be touched. The files can be removed again with:
 
 .. code-block:: bash
 
-    $ sudo make clean
+    $ sudo make uninstall
 
 
 Testing

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,14 @@ configuration files won't be touched. The files can be removed again with:
 Testing
 -------
 
+To run unit tests use the *test* target of the :file:`Makefile`:
+
+.. code-block:: bash
+
+    $ make test
+
+Or use the Python unittest module to discover tests directly:
+
 .. code-block:: python
 
     python -m unittest discover

--- a/hooks
+++ b/hooks
@@ -121,7 +121,7 @@ def delete_chain(table, name):
     subprocess.call([IPTABLES_BINARY, "-t", table, "-F", name])
     subprocess.call([IPTABLES_BINARY, "-t", table, "-X", name])
 
-def populate_chains(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip, domain, source_ip):
+def populate_chains(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip, domain, source_ip=None):
     """ Fills the two custom chains with the port mappings. """
     port_map = domain["port_map"]
     for protocol in port_map:
@@ -168,7 +168,7 @@ def disable_bridge_filtering():
             brnf.write('0\n')
 
 
-def start_forwarding(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip, domain, source_ip):
+def start_forwarding(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip, domain, source_ip=None):
     """ sets up iptables port-forwarding rules based on the port_map. """
     disable_bridge_filtering()
     create_chain("nat", dnat_chain)

--- a/hooks
+++ b/hooks
@@ -15,7 +15,7 @@ import re
 import subprocess
 import sys
 
-# python 2.6 support 
+# python 2.6 support
 if "check_output" not in dir( subprocess ):
     def f(*popenargs, **kwargs):
         if 'stdout' in kwargs:
@@ -187,9 +187,12 @@ def insert_chains(action, dnat_chain, snat_chain, fwd_chain, public_ip, private_
     subprocess.call([IPTABLES_BINARY, "-t", "nat", action,
                      "PREROUTING", "-d", public_ip, "-j", dnat_chain])
     subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "POSTROUTING",
+                    "-s", private_ip, "-p", "all", "-j", "SNAT", "--to-source", public_ip])
+    subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "POSTROUTING",
                      "-s", private_ip, "-d", private_ip, "-j", snat_chain])
     subprocess.call([IPTABLES_BINARY, "-t", "filter", action,
                      "FORWARD", "-d", private_ip, "-j", fwd_chain])
+
 
 # the snat_chain doesn't work unless we turn off filtering bridged packets
 

--- a/hooks
+++ b/hooks
@@ -15,6 +15,21 @@ import re
 import subprocess
 import sys
 
+# python 2.6 support 
+if "check_output" not in dir( subprocess ):
+    def f(*popenargs, **kwargs):
+        if 'stdout' in kwargs:
+            raise ValueError('stdout argument not allowed, it will be overridden.')
+        process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
+        output, unused_err = process.communicate()
+        retcode = process.poll()
+        if retcode:
+            cmd = kwargs.get("args")
+            if cmd is None:
+                cmd = popenargs[0]
+            raise subprocess.CalledProcessError(retcode, cmd)
+        return output
+    subprocess.check_output = f
 
 CONFIG_PATH = os.getenv('CONFIG_PATH') or os.path.dirname(
     os.path.abspath(__file__))

--- a/hooks
+++ b/hooks
@@ -16,10 +16,14 @@ import subprocess
 import sys
 
 
-CONFIG_PATH = os.getenv('CONFIG_PATH') or os.path.dirname(os.path.abspath(__file__))
-CONFIG_FILENAME = os.getenv('CONFIG_FILENAME') or os.path.join(CONFIG_PATH, "hooks.json")
-CONFIG_SCHEMA_FILENAME = os.getenv('CONFIG_SCHEMA_FILENAME') or os.path.join(CONFIG_PATH, "hooks.schema.json")
-IPTABLES_BINARY = os.getenv('IPTABLES_BINARY') or subprocess.check_output(["which", "iptables"]).strip()
+CONFIG_PATH = os.getenv('CONFIG_PATH') or os.path.dirname(
+    os.path.abspath(__file__))
+CONFIG_FILENAME = os.getenv('CONFIG_FILENAME') or os.path.join(
+    CONFIG_PATH, "hooks.json")
+CONFIG_SCHEMA_FILENAME = os.getenv('CONFIG_SCHEMA_FILENAME') or os.path.join(
+    CONFIG_PATH, "hooks.schema.json")
+IPTABLES_BINARY = os.getenv('IPTABLES_BINARY') or subprocess.check_output([
+    "which", "iptables"]).strip()
 
 
 # Allow comments in json, copied from https://github.com/getify/JSON.minify
@@ -78,9 +82,12 @@ def host_ip():
     """
     if not hasattr(host_ip, "_host_ip"):
         cmd = "ip route | grep default | cut -d' ' -f5 | head -n1"
-        default_route_interface = subprocess.check_output(cmd, shell=True).decode().strip()
-        cmd = "ip addr show {0} | grep -E 'inet .*{0}' | cut -d' ' -f6 | cut -d'/' -f1".format(default_route_interface)
-        host_ip._host_ip = subprocess.check_output(cmd, shell=True).decode().strip()
+        default_route_interface = subprocess.check_output(
+            cmd, shell=True).decode().strip()
+        cmd = "ip addr show {0} | grep -E 'inet .*{0}' | cut -d' ' -f6 | cut -d'/' -f1".format(
+            default_route_interface)
+        host_ip._host_ip = subprocess.check_output(
+            cmd, shell=True).decode().strip()
     return host_ip._host_ip.split('\n')[0]
 
 
@@ -111,15 +118,16 @@ def config(validate=True):
     return config._conf
 
 
-
 def create_chain(table, name):
     """ Creates the named chain. """
     subprocess.call([IPTABLES_BINARY, "-t", table, "-N", name])
+
 
 def delete_chain(table, name):
     """ Flushes and deletes the named chain. """
     subprocess.call([IPTABLES_BINARY, "-t", table, "-F", name])
     subprocess.call([IPTABLES_BINARY, "-t", table, "-X", name])
+
 
 def populate_chains(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip, domain, source_ip=None):
     """ Fills the two custom chains with the port mappings. """
@@ -127,40 +135,50 @@ def populate_chains(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip, do
     for protocol in port_map:
         for ports in port_map[protocol]:
             # a single integer 80 is equivalent to [80, 80]
-            public_port, private_port = ports if isinstance(ports, list) else [ports, ports]
+            public_port, private_port = ports if isinstance(ports, list) else [
+                ports, ports]
             dest = "{0}:{1}".format(private_ip, str(private_port))
             subprocess.call([IPTABLES_BINARY, "-t", "nat", "-A", dnat_chain, "-p", protocol,
-                "-d", public_ip, "--dport", str(public_port), "-j", "DNAT", "--to", dest] +
-                (["-s", source_ip] if source_ip else []))
+                             "-d", public_ip, "--dport", str(public_port), "-j", "DNAT", "--to", dest] +
+                            (["-s", source_ip] if source_ip else []))
             subprocess.call([IPTABLES_BINARY, "-t", "nat", "-A", snat_chain, "-p", protocol,
-                "-s", private_ip, "-d", private_ip, "--dport", str(public_port), "-j", "MASQUERADE"])
-            interface = ["-o", domain["interface"]] if "interface" in domain else []
+                             "-s", private_ip, "-d", private_ip, "--dport", str(public_port), "-j", "MASQUERADE"])
+            interface = ["-o", domain["interface"]
+                         ] if "interface" in domain else []
             subprocess.call([IPTABLES_BINARY, "-t", "filter", "-A", fwd_chain, "-p", protocol,
-                "-d", private_ip, "--dport", str(private_port), "-j", "ACCEPT"] + interface)
+                             "-d", private_ip, "--dport", str(private_port), "-j", "ACCEPT"] + interface)
 
-            
     # Iterate over all port ranges
     if "port_range" in domain:
         for port_range in domain["port_range"]:
-            ports_range = (str(port_range["init_port"]) + ":" + 
-                str(port_range["init_port"] + port_range["ports_num"] -1))
-            dest = "{0}:{1}".format(private_ip, ports_range.replace(":", "-", 1))
+            ports_range = (str(port_range["init_port"]) + ":" +
+                           str(port_range["init_port"] + port_range["ports_num"] - 1))
+            dest = "{0}:{1}".format(
+                private_ip, ports_range.replace(":", "-", 1))
             subprocess.call([IPTABLES_BINARY, "-t", "nat", "-A", dnat_chain, "-p", port_range["protocol"],
-                "-d", public_ip, "--dport", ports_range, "-j", "DNAT", "--to", dest])
+                             "-d", public_ip, "--dport", ports_range, "-j", "DNAT", "--to", dest])
             subprocess.call([IPTABLES_BINARY, "-t", "nat", "-A", snat_chain, "-p", port_range["protocol"],
-                "-s", private_ip, "-d", private_ip, "--dport", ports_range, "-j", "MASQUERADE"])
-            interface = ["-o", domain["interface"]] if "interface" in domain else []
+                             "-s", private_ip, "-d", private_ip, "--dport", ports_range, "-j", "MASQUERADE"])
+            interface = ["-o", domain["interface"]
+                         ] if "interface" in domain else []
             subprocess.call([IPTABLES_BINARY, "-t", "filter", "-A", fwd_chain, "-p", port_range["protocol"],
-                "-d", private_ip, "--dport", ports_range, "-j", "ACCEPT"] + interface)
+                             "-d", private_ip, "--dport", ports_range, "-j", "ACCEPT"] + interface)
+
 
 def insert_chains(action, dnat_chain, snat_chain, fwd_chain, public_ip, private_ip):
     """ inserts (action='-I') or removes (action='-D') the custom chains."""
-    subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "OUTPUT", "-d", public_ip, "-j", dnat_chain])
-    subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "PREROUTING", "-d", public_ip, "-j", dnat_chain])
-    subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "POSTROUTING", "-s", private_ip, "-d", private_ip, "-j", snat_chain])
-    subprocess.call([IPTABLES_BINARY, "-t", "filter", action, "FORWARD", "-d", private_ip, "-j", fwd_chain])
+    subprocess.call([IPTABLES_BINARY, "-t", "nat", action,
+                     "OUTPUT", "-d", public_ip, "-j", dnat_chain])
+    subprocess.call([IPTABLES_BINARY, "-t", "nat", action,
+                     "PREROUTING", "-d", public_ip, "-j", dnat_chain])
+    subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "POSTROUTING",
+                     "-s", private_ip, "-d", private_ip, "-j", snat_chain])
+    subprocess.call([IPTABLES_BINARY, "-t", "filter", action,
+                     "FORWARD", "-d", private_ip, "-j", fwd_chain])
 
 # the snat_chain doesn't work unless we turn off filtering bridged packets
+
+
 def disable_bridge_filtering():
     proc_file = '/proc/sys/net/bridge/bridge-nf-call-iptables'
     if(os.path.isfile(proc_file)):
@@ -174,14 +192,17 @@ def start_forwarding(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip, d
     create_chain("nat", dnat_chain)
     create_chain("nat", snat_chain)
     create_chain("filter", fwd_chain)
-    populate_chains(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip, domain, source_ip)
+    populate_chains(dnat_chain, snat_chain, fwd_chain,
+                    public_ip, private_ip, domain, source_ip)
 
-    insert_chains("-I", dnat_chain, snat_chain, fwd_chain, public_ip, private_ip)
+    insert_chains("-I", dnat_chain, snat_chain,
+                  fwd_chain, public_ip, private_ip)
 
 
 def stop_forwarding(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip):
     """ tears down the iptables port-forwarding rules. """
-    insert_chains("-D", dnat_chain, snat_chain, fwd_chain, public_ip, private_ip)
+    insert_chains("-D", dnat_chain, snat_chain,
+                  fwd_chain, public_ip, private_ip)
     delete_chain("nat", dnat_chain)
     delete_chain("nat", snat_chain)
     delete_chain("filter", fwd_chain)
@@ -201,6 +222,8 @@ if __name__ == "__main__":
     source_ip = domain.get("source_ip")
 
     if action in ["stopped", "reconnect"]:
-        stop_forwarding(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip)
+        stop_forwarding(dnat_chain, snat_chain,
+                        fwd_chain, public_ip, private_ip)
     if action in ["start", "reconnect"]:
-        start_forwarding(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip, domain, source_ip)
+        start_forwarding(dnat_chain, snat_chain, fwd_chain,
+                         public_ip, private_ip, domain, source_ip)

--- a/hooks
+++ b/hooks
@@ -182,6 +182,7 @@ def populate_chains(dnat_chain, snat_chain, fwd_chain, public_ip, private_ip, do
 
 def insert_chains(action, dnat_chain, snat_chain, fwd_chain, public_ip, private_ip):
     """ inserts (action='-I') or removes (action='-D') the custom chains."""
+<<<<<<< HEAD
     subprocess.call([IPTABLES_BINARY, "-t", "nat", action,
                      "OUTPUT", "-d", public_ip, "-j", dnat_chain])
     subprocess.call([IPTABLES_BINARY, "-t", "nat", action,
@@ -193,6 +194,14 @@ def insert_chains(action, dnat_chain, snat_chain, fwd_chain, public_ip, private_
     subprocess.call([IPTABLES_BINARY, "-t", "filter", action,
                      "FORWARD", "-d", private_ip, "-j", fwd_chain])
 
+=======
+    subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "OUTPUT", "-d", public_ip, "-j", dnat_chain])
+    subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "PREROUTING", "-d", public_ip, "-j", dnat_chain])
+    subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "POSTROUTING", "-s", private_ip, "-p", "all", 
+                    "-j", "SNAT", "--to-source", public_ip])
+    subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "POSTROUTING", "-s", private_ip, "-d", private_ip, "-j", snat_chain])
+    subprocess.call([IPTABLES_BINARY, "-t", "filter", action, "FORWARD", "-d", private_ip, "-j", fwd_chain])
+>>>>>>> 749a4f32020be34bd608c50dbfd922bbf21d87cd
 
 # the snat_chain doesn't work unless we turn off filtering bridged packets
 

--- a/hooks
+++ b/hooks
@@ -6,7 +6,7 @@ Libvirt hook for setting up iptables port-forwarding rules when using NAT-ed
 networking.
 """
 __author__ = "Sascha Peilicke <saschpe@gmx.de>"
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 
 import os

--- a/hooks.schema.json
+++ b/hooks.schema.json
@@ -58,7 +58,7 @@
                                           "type": "string",
                                           "enum": ["tcp", "udp", "icmp"] }
                         },
-                        "required": ["init_port", "port_num", "protocol"], 
+                        "required": ["init_port", "ports_num", "protocol"], 
                         "additionalItems": false
                     },
                     "additionalItems": false,

--- a/test_qemu.py
+++ b/test_qemu.py
@@ -12,6 +12,7 @@ qemu = imp.load_source('hooks', 'hooks')
 
 
 class QemuTestCase(unittest.TestCase):
+
     def test_host_ip(self):
         host_ip = qemu.host_ip()
         try:
@@ -77,14 +78,16 @@ class QemuTestCase(unittest.TestCase):
 
         # stub out the disable_bridge_filtering call
         self.bridge_nf = False
+
         def disable_bridge_filtering():
             self.bridge_nf = True
         self.old_bridge_filtering = qemu.disable_bridge_filtering
         qemu.disable_bridge_filtering = disable_bridge_filtering
 
         def test_func():
-            domain = { "port_map": port_map, "interface": "virbr0" }
-            qemu.start_forwarding("DNAT-test", "SNAT-test", "FWD-test", "192.168.1.1", "127.0.0.1", domain)
+            domain = {"port_map": port_map, "interface": "virbr0"}
+            qemu.start_forwarding("DNAT-test", "SNAT-test",
+                                  "FWD-test", "192.168.1.1", "127.0.0.1", domain)
 
         output = self.capture_output(test_func)
         self.maxDiff = None
@@ -108,7 +111,8 @@ class QemuTestCase(unittest.TestCase):
         """)
 
         def test_func():
-            qemu.stop_forwarding("DNAT-test", "SNAT-test", "FWD-test", "192.168.1.1", "127.0.0.1")
+            qemu.stop_forwarding("DNAT-test", "SNAT-test",
+                                 "FWD-test", "192.168.1.1", "127.0.0.1")
 
         output = self.capture_output(test_func)
         self.maxDiff = None


### PR DESCRIPTION
For example in a mail server, it is important to have the correct source IP for _outgoing_ connections (e.g. when the guest is making SMTP connection to another mail server, we need this connection to come from an IP with correct reverse lookup, otherwise the mail might not be accepted).

This PR adds an SNAT rule to masquerade the outgoing connections accordingly. I'm no expert with virtual networking, so I can't tell whether this is the correct or best way to achieve it, but it seems to work here.