### PR TITLE
Fix typo in hooks.schema.json

### DIFF
--- a/hooks.schema.json
+++ b/hooks.schema.json
@@ -58,7 +58,7 @@
                                           "type": "string",
                                           "enum": ["tcp", "udp", "icmp"] }
                         },
-                        "required": ["init_port", "port_num", "protocol"], 
+                        "required": ["init_port", "ports_num", "protocol"], 
                         "additionalItems": false
                     },
                     "additionalItems": false,


### PR DESCRIPTION
In `port_range` `port_num` was required instead of `ports_num`.