### PR TITLE
masquerade outgoing connections to public_ip (rebasing PR #21 on master)

### DIFF
--- a/hooks
+++ b/hooks
@@ -15,7 +15,7 @@ import re
 import subprocess
 import sys
 
-# python 2.6 support 
+# python 2.6 support
 if "check_output" not in dir( subprocess ):
     def f(*popenargs, **kwargs):
         if 'stdout' in kwargs:
@@ -186,6 +186,8 @@ def insert_chains(action, dnat_chain, snat_chain, fwd_chain, public_ip, private_
                      "OUTPUT", "-d", public_ip, "-j", dnat_chain])
     subprocess.call([IPTABLES_BINARY, "-t", "nat", action,
                      "PREROUTING", "-d", public_ip, "-j", dnat_chain])
+    subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "POSTROUTING",
+                    "-s", private_ip, "-p", "all", "-j", "SNAT", "--to-source", public_ip])
     subprocess.call([IPTABLES_BINARY, "-t", "nat", action, "POSTROUTING",
                      "-s", private_ip, "-d", private_ip, "-j", snat_chain])
     subprocess.call([IPTABLES_BINARY, "-t", "filter", action,


### PR DESCRIPTION
For example in a mail server, it is important to have the correct source IP for outgoing connections (e.g. when the guest is making SMTP connection to another mail server, we need this connection to come from an IP with correct reverse lookup, otherwise the mail might not be accepted).

This PR adds an SNAT rule to masquerade the outgoing connections accordingly. I'm no expert with virtual networking, so I can't tell whether this is the correct or best way to achieve it, but it seems to work here.

This is an rebased version of PR #21, which I apparently messed up.